### PR TITLE
Use Concurrent::CachedThreadPool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     umbra-rb (0.2.0)
+      concurrent-ruby (~> 1.1)
       multi_json (~> 1.13)
       oj (~> 3.9)
       redis (~> 4.1)
@@ -16,6 +17,7 @@ GEM
       rubocop-performance
       rubocop-rspec
     coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)

--- a/lib/umbra.rb
+++ b/lib/umbra.rb
@@ -3,6 +3,7 @@
 require 'typhoeus'
 require 'redis'
 require 'multi_json'
+require 'concurrent'
 
 module Umbra
   autoload :Config, 'umbra/config'

--- a/umbra-rb.gemspec
+++ b/umbra-rb.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
+  spec.add_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_dependency 'multi_json', '~> 1.13'
   spec.add_dependency 'oj', '~> 3.9'
   spec.add_dependency 'redis', '~> 4.1'


### PR DESCRIPTION
Use `concurrent-ruby`'s `Concurrent::CachedThreadPool`.
No need to have re-invented the wheel, although it was fun.