### PR TITLE
Add minimal rack app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    rack (2.0.7)
     rainbow (3.0.0)
     rake (13.0.1)
     redis (4.1.3)
@@ -69,6 +70,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   carwow_rubocop
   pry
+  rack
   rake (~> 13.0)
   rspec (~> 3.0)
   umbra-rb!

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,8 @@
+require 'rack'
+require 'rack/lobster'
+require 'umbra'
+
+Umbra.configure
+
+use Umbra::Middleware
+run Rack::Lobster.new

--- a/umbra-rb.gemspec
+++ b/umbra-rb.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'carwow_rubocop'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 


### PR DESCRIPTION
Adds a minimal rack app via `Rack::Lobster` that can be used for
local testing and perhaps for some integration tests soon.