### PR TITLE
Ensure we have a connection to redis before subscribing

### DIFF
--- a/lib/umbra/subscriber.rb
+++ b/lib/umbra/subscriber.rb
@@ -1,13 +1,16 @@
 module Umbra
   class Subscriber
-    def initialize(worker)
+    def initialize(worker, redis: Umbra.redis)
       @worker = worker
+      @redis = redis
     end
 
     def start
-      Umbra.redis.subscribe(Umbra::CHANNEL) do |on|
-        on.message do |_, message|
-          @worker.call(MultiJson.load(message))
+      @redis.ensure_connected do
+        @redis.subscribe(Umbra::CHANNEL) do |on|
+          on.message do |_, message|
+            @worker.call(MultiJson.load(message))
+          end
         end
       end
     end


### PR DESCRIPTION
We don't currently handle the connection to redis failing.

This change in combination with setting [reconnection options](https://github.com/redis/redis-rb#reconnections) on the redis client should help to make publishing more robust.