### PR TITLE
Use Typhoeus::Hydra for parallel requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     carwow_rubocop (3.2.0)
       rubocop (>= 0.78)
@@ -18,10 +20,13 @@ GEM
       rubocop-rspec
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     ffi (1.11.1)
+    hashdiff (1.0.0)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
     multi_json (1.14.1)
@@ -32,6 +37,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (4.0.3)
     rack (2.1.1)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -61,9 +67,14 @@ GEM
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
     unicode-display_width (1.6.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -76,6 +87,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   umbra-rb!
+  webmock (~> 2)
 
 BUNDLED WITH
    2.0.2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'umbra'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/umbra/shadow_requester_spec.rb
+++ b/spec/umbra/shadow_requester_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Umbra::ShadowRequester do
+  let(:count) { 10 }
+  let(:instance) { described_class.new(count: count) }
+  let(:env) do
+    {
+      'request' => {
+        'method' => 'GET',
+        'scheme' => 'http',
+        'host' => 'www.example.com',
+        'body' => '',
+        'query' => '',
+        'script_name' => '',
+        'path_info' => '',
+        'headers' => {}
+      }
+    }
+  end
+
+  describe '#call!' do
+    it 'makes count requests' do
+      stub_request(:get, 'www.example.com')
+
+      instance.call!(env)
+
+      expect(WebMock).to have_requested(:get, 'www.example.com').times(count)
+    end
+  end
+end

--- a/umbra-rb.gemspec
+++ b/umbra-rb.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock', '~> 2'
 
   spec.add_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_dependency 'multi_json', '~> 1.13'


### PR DESCRIPTION
Instead of pushing replicated requests to the queue @count times, wrap them in
a `Typhoeus::Hydra` object and push them once, letting `Typhoeus` handling
making them in parallel.
