### PR TITLE
Move *sync.WaitGroup.Add() outside of goroutine

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -40,6 +40,7 @@ func New(concurrency, buffer int, timeout time.Duration, collect collector.Colle
 // Start begins the background workers for the pool
 func (pool *Config) Start() Pool {
 	for i := 0; i < pool.concurrency; i++ {
+		pool.wg.Add(1)
 		go pool.work()
 	}
 
@@ -74,7 +75,6 @@ func (pool *Config) Stop() {
 }
 
 func (pool *Config) work() {
-	pool.wg.Add(1)
 	defer pool.wg.Done()
 
 	for request := range pool.channel {


### PR DESCRIPTION
There was actually a very subtle race condition with having the `Add`
within the gorouting.

If a process were to Start and then Stop very quickly it is possible
that a goroutine would have been started but not have ran `Add` wait, so
we don't wait for that goroutine to be `Done` correctly with `Wait`.

Pulling the call out to be before the goroutine starts fixes this
potential issue.